### PR TITLE
Usability Tweaks

### DIFF
--- a/front-end/public/ngl-web-component.js
+++ b/front-end/public/ngl-web-component.js
@@ -17,7 +17,7 @@ class NGLViewer extends HTMLElement {
   showStructure() {
     const pdbString = this.getAttribute("pdb-string");
 
-    var stage = new Stage(this.id);
+    var stage = new Stage(this.id, { backgroundColor: "#BEBEBE" });
     var stringBlob = new Blob([pdbString], { type: "text/plain" });
     stage.loadFile(stringBlob, { ext: "pdb" }).then(function (component) {
       component.addRepresentation("cartoon");

--- a/front-end/src/Pages/Designs.elm
+++ b/front-end/src/Pages/Designs.elm
@@ -716,6 +716,33 @@ update msg model =
                     |> Tuple.mapSecond (\c -> c :: cmds |> Cmd.batch)
 
 
+aaLetterTo3Letter : Dict String String
+aaLetterTo3Letter =
+    [ ( "A", "ALA" )
+    , ( "C", "CYS" )
+    , ( "D", "ASP" )
+    , ( "E", "GLU" )
+    , ( "F", "PHE" )
+    , ( "G", "GLY" )
+    , ( "H", "HIS" )
+    , ( "I", "ILE" )
+    , ( "K", "LYS" )
+    , ( "L", "LEU" )
+    , ( "M", "MET" )
+    , ( "N", "ASN" )
+    , ( "P", "PRO" )
+    , ( "Q", "GLN" )
+    , ( "R", "ARG" )
+    , ( "S", "SER" )
+    , ( "T", "THR" )
+    , ( "V", "VAL" )
+    , ( "W", "TRP" )
+    , ( "X", "UNK" )
+    , ( "Y", "TYR" )
+    ]
+        |> Dict.fromList
+
+
 designStubCSVEncoder : Design.DesignStub -> List ( String, String )
 designStubCSVEncoder designStub =
     let
@@ -730,7 +757,9 @@ designStubCSVEncoder designStub =
 
         createCompLine : Dict String Float -> String -> ( String, String )
         createCompLine compDict label =
-            ( "composition: " ++ label
+            ( Dict.get label aaLetterTo3Letter
+                |> Maybe.withDefault "UNK"
+                |> (++) "composition: "
             , Dict.get label compDict
                 |> Maybe.withDefault 0.0
                 |> String.fromFloat

--- a/front-end/src/Pages/Designs.elm
+++ b/front-end/src/Pages/Designs.elm
@@ -1818,7 +1818,9 @@ overviewSpec device plotData =
 
         metricValueBarSpec ( label, _, sortProp ) =
             VL.asSpec
-                [ VL.bar []
+                [ VL.bar
+                    [ VL.maTooltip VL.ttEncoding
+                    ]
                 , VL.title label []
                 , VL.width 200
                 , (VL.encoding
@@ -1832,6 +1834,7 @@ overviewSpec device plotData =
                         , VL.pAxis
                             [ VL.axLabelExpr
                                 "split(datum.label, '@@@')[0]"
+                            , VL.axTitle ""
                             ]
                         ]
                     << VL.position VL.X

--- a/front-end/src/Pages/Designs.elm
+++ b/front-end/src/Pages/Designs.elm
@@ -1481,7 +1481,7 @@ designCardView { uuidString, designStub, mMeetsSpecification, selected } =
                 , DesignDetails uuidString
                     |> Events.onClick
                 ]
-                [ Style.h2 <| text designStub.name
+                [ el [ Font.underline ] <| Style.h2 <| text designStub.name
                 , paragraph []
                     [ WebSockets.metricsJobStatusString designStub.metricsJobStatus
                         |> text

--- a/front-end/src/Pages/Designs/Uuid_String.elm
+++ b/front-end/src/Pages/Designs/Uuid_String.elm
@@ -1336,6 +1336,12 @@ metricsHistogramsView : Element msg
 metricsHistogramsView =
     column [ width fill ]
         [ Style.h3 <| text "Metrics Histograms"
+        , paragraph
+            []
+            [ """The black vertical line shows the value for the design.
+ Hover over the
+              line to see the exact value.
+              """ |> text ]
         , Keyed.el [ centerX ]
             ( "metricsHistograms"
             , Html.div

--- a/front-end/src/Pages/ReferenceSets/Uuid_String.elm
+++ b/front-end/src/Pages/ReferenceSets/Uuid_String.elm
@@ -4,10 +4,12 @@ import Browser.Navigation as Nav
 import Codec exposing (Value)
 import Dict
 import Element exposing (..)
+import Element.Border as Border
 import Element.Font as Font
 import Element.Keyed as Keyed
 import Html
 import Html.Attributes as HAtt
+import Round
 import Shared
 import Shared.Buttons as Buttons
 import Shared.Folds as Folds
@@ -329,6 +331,7 @@ simpleDetails :
         { a
             | name : String
             , description : String
+            , aggregateData : Metrics.AggregateData
             , deleteStatus : Buttons.DangerStatus
         }
     -> Element Msg
@@ -357,6 +360,9 @@ simpleDetails uuidString refSetOrStub =
             , paragraph
                 []
                 [ text refSetOrStub.description ]
+            , Style.h2 <|
+                text "Aggregate Data"
+            , aggregateDataTable refSetOrStub.aggregateData
             ]
         ]
 
@@ -368,6 +374,7 @@ fullDetails :
         { a
             | name : String
             , description : String
+            , aggregateData : Metrics.AggregateData
             , deleteStatus : Buttons.DangerStatus
             , metrics : List RefSetMetrics
         }
@@ -398,6 +405,60 @@ fullDetails uuidString displaySettings referenceSet =
                     ]
             }
         , referenceOverview
+        ]
+
+
+roundFloatText : Float -> Int -> Element msg
+roundFloatText value digits =
+    text (Round.round digits value)
+
+
+aggregateDataTable : Metrics.AggregateData -> Element msg
+aggregateDataTable aggregateData =
+    let
+        collatedData =
+            [ aggregateData.hydrophobicFitness
+            , aggregateData.isoelectricPoint
+            , aggregateData.numberOfResidues
+            , aggregateData.packingDensity
+            , aggregateData.budeFFTotalEnergy
+            , aggregateData.evoEFTotalEnergy
+            , aggregateData.dfireTotalEnergy
+            , aggregateData.rosettaTotalEnergy
+            , aggregateData.aggrescan3dTotalValue
+            ]
+                |> List.filterMap identity
+                |> List.map2 Tuple.pair
+                    [ "Hydrophobic Fitness"
+                    , "Isoelectric Point"
+                    , "Number Of Residues"
+                    , "Packing Density"
+                    , "BudeFF Total Energy"
+                    , "EvoEF Total Energy"
+                    , "Dfire Total Energy"
+                    , "Rosetta Total Energy"
+                    , "Aggrescan3d Total Value"
+                    ]
+    in
+    column
+        [ width fill ]
+        (row [ padding 5, width fill, Border.widthXY 0 2, Font.bold ]
+            [ el [ width <| fillPortion 1 ] <| text "Metric"
+            , el [ width <| fillPortion 1, Font.alignRight ] <| text "Mean"
+            , el [ width <| fillPortion 1, Font.alignRight ] <| text "Median"
+            , el [ width <| fillPortion 1, Font.alignRight ] <| text "Std Dev"
+            ]
+            :: List.map rowView collatedData
+        )
+
+
+rowView : ( String, Metrics.MeanMedAndStdDev ) -> Element msg
+rowView ( name, { mean, median, stdDev } ) =
+    row [ padding 5, spacing 5, width fill, Border.widthEach { top = 0, bottom = 1, left = 0, right = 0 } ]
+        [ paragraph [ width <| fillPortion 1 ] [ text name ]
+        , el [ width <| fillPortion 1, Font.alignRight ] <| roundFloatText mean 2
+        , el [ width <| fillPortion 1, Font.alignRight ] <| roundFloatText median 2
+        , el [ width <| fillPortion 1, Font.alignRight ] <| roundFloatText stdDev 2
         ]
 
 

--- a/front-end/src/Shared/Metrics.elm
+++ b/front-end/src/Shared/Metrics.elm
@@ -735,7 +735,9 @@ createAllHistogramsSpec device designHistPlotData refSetHistPlotData =
                 [ VL.width 200
                 , VL.layer
                     (VL.asSpec
-                        [ VL.bar []
+                        [ VL.bar
+                            [ VL.maTooltip VL.ttEncoding
+                            ]
                         , refSetData []
                         , (VL.encoding
                             << VL.position VL.X
@@ -756,13 +758,15 @@ createAllHistogramsSpec device designHistPlotData refSetHistPlotData =
 
                             else
                                 [ VL.asSpec
-                                    [ VL.rule [ VL.maSize 3 ]
+                                    [ VL.rule
+                                        [ VL.maSize 3
+                                        , VL.maTooltip VL.ttEncoding
+                                        ]
                                     , designSetData []
                                     , (VL.encoding
                                         << VL.position VL.X
                                             [ VL.pName ("design_" ++ label)
                                             , VL.pMType VL.Quantitative
-                                            , VL.pAxis [ VL.axTitle "" ]
                                             ]
                                       )
                                         []
@@ -896,7 +900,7 @@ createCompositionSpec device aggregateData mDesignMetrics =
                 (Just designComposition)
                 (Dict.toList aggregateData.composition
                     |> List.map
-                        (\( k, v ) -> ( k, Maybe.map .mean v |> Maybe.withDefault 0 ))
+                        (\( k, v ) -> ( k, Maybe.map .median v |> Maybe.withDefault 0 ))
                     |> Dict.fromList
                 )
 
@@ -906,7 +910,7 @@ createCompositionSpec device aggregateData mDesignMetrics =
                 Nothing
                 (Dict.toList aggregateData.composition
                     |> List.map
-                        (\( k, v ) -> ( k, Maybe.map .mean v |> Maybe.withDefault 0 ))
+                        (\( k, v ) -> ( k, Maybe.map .median v |> Maybe.withDefault 0 ))
                     |> Dict.fromList
                 )
 
@@ -955,15 +959,8 @@ compositionSpec device mDesignCompositionDict pdbCompositionDict =
                         )
                             ++ List.repeat
                                 (List.length <| Dict.keys pdbCompositionDict)
-                                "Reference"
+                                "Median Reference Set Value"
                     )
-
-        config =
-            (VL.configure
-                << VL.configuration (VL.coView [ VL.vicoStroke <| Just "transparent" ])
-                << VL.configuration (VL.coAxis [ VL.axcoDomainWidth 1 ])
-            )
-                []
     in
     VL.toVegaLite
         [ data []
@@ -971,22 +968,25 @@ compositionSpec device mDesignCompositionDict pdbCompositionDict =
         , VL.width <|
             case ( device.class, device.orientation ) of
                 ( Phone, Portrait ) ->
-                    200
+                    12
 
                 _ ->
-                    400
+                    25
         , VL.bar
-            []
+            [ VL.maTooltip VL.ttEncoding
+            ]
         , (VL.encoding
+            << VL.column [ VL.fName "Amino Acids", VL.fNominal, VL.fSpacing 1 ]
             << VL.position VL.Y
                 [ VL.pName "Proportion"
-                , VL.pAggregate VL.opSum
                 , VL.pMType VL.Quantitative
-                , VL.pAxis [ VL.axTitle "Amino Acid Proportion", VL.axGrid True ]
+                , VL.pAggregate VL.opSum
+                , VL.pAxis [ VL.axTitle "Amino Acid Proportion", VL.axGrid False ]
                 ]
             << VL.position VL.X
-                [ VL.pName "Amino Acids"
+                [ VL.pName "Set"
                 , VL.pMType VL.Nominal
+                , VL.pAxis []
                 ]
             << VL.color
                 [ VL.mName "Set"
@@ -998,7 +998,6 @@ compositionSpec device mDesignCompositionDict pdbCompositionDict =
                 ]
           )
             []
-        , config
         ]
 
 
@@ -1155,7 +1154,7 @@ fullTorsionAnglesSpec device designTorsionAngles pdbTorsionAnglesDicts =
                 , pdbData []
                 , sel []
                 , VL.tick
-                    [ VL.maOpacity 0.2
+                    [ VL.maOpacity 0.01
                     ]
                 , (VL.encoding
                     << VL.position VL.X
@@ -1247,7 +1246,7 @@ refSetTorsionAnglesSpec device pdbTorsionAnglesDicts =
                 , pdbData []
                 , sel []
                 , VL.tick
-                    [ VL.maOpacity 0.2
+                    [ VL.maOpacity 0.01
                     ]
                 , (VL.encoding
                     << VL.position VL.X

--- a/front-end/src/Shared/Requirement.elm
+++ b/front-end/src/Shared/Requirement.elm
@@ -92,7 +92,7 @@ resolveRequirement mAggregateData metrics requirement =
                                     resolveCompositionDeviation
                                         unitType
                                         threshold
-                                        aggregateData.meanComposition
+                                        aggregateData.composition
                                         metrics.composition
 
                                 Nothing ->
@@ -147,7 +147,7 @@ resolveRequirement mAggregateData metrics requirement =
 resolveCompositionDeviation :
     UnitType
     -> Float
-    -> Dict String (Maybe Metrics.MeanAndStdDev)
+    -> Dict String (Maybe Metrics.MeanMedAndStdDev)
     -> Dict String Float
     -> Bool
 resolveCompositionDeviation unitType threshold meanComposition designComposition =


### PR DESCRIPTION
Addresses many of the usability issues that have arisen from the beta. This includes:

* Tooltip on most plots
* Tidying the plots to make them more readable
* Fixing the composition plot
* Moving most reference set values in plots to median rather than mean to account for skew
* Adds a table with aggregated metrics to reference set details
* Adds bars on the designs overview for each reference set
* Makes export more prominent
* Makes tagging simpler and intuitive
* Moves delete all designs to control panel
* Adds button to delete selected designs
* Makes CSV headers more readable
* Changes structure view background colour