### PR TITLE
Fix: Added in error handling when running dssp from isambard

### DIFF
--- a/big-structure/src/destress_big_structure/analysis.py
+++ b/big-structure/src/destress_big_structure/analysis.py
@@ -256,7 +256,17 @@ def analyse_design(design: ampal.Assembly) -> DesignMetrics:
     assert (
         AGGRESCAN3D_SCRIPT_PATH
     ), "AGGRESCAN3D_SCRIPT_PATH is not defined, check you `.env` file"
-    ev.tag_dssp_data(design)
+
+    try:
+        ev.tag_dssp_data(design)
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(
+            "command '{}' return with error (code {}): {}".format(
+                e.cmd, e.returncode, e.output
+            )
+        )
+        print("Error with Isambard Tag DSSP")
+
     sequence_info = {
         chain.id: SequenceInfo(
             sequence="".join(m.mol_letter for m in chain),

--- a/big-structure/src/destress_big_structure/analysis.py
+++ b/big-structure/src/destress_big_structure/analysis.py
@@ -260,12 +260,8 @@ def analyse_design(design: ampal.Assembly) -> DesignMetrics:
     try:
         ev.tag_dssp_data(design)
     except subprocess.CalledProcessError as e:
-        raise RuntimeError(
-            "command '{}' return with error (code {}): {}".format(
-                e.cmd, e.returncode, e.output
-            )
-        )
-        print("Error with Isambard Tag DSSP")
+        print(e.stdout)
+        pass
 
     sequence_info = {
         chain.id: SequenceInfo(

--- a/big-structure/src/destress_big_structure/analysis.py
+++ b/big-structure/src/destress_big_structure/analysis.py
@@ -261,6 +261,11 @@ def analyse_design(design: ampal.Assembly) -> DesignMetrics:
         ev.tag_dssp_data(design)
     except subprocess.CalledProcessError as e:
         print(e)
+        raise RuntimeError(
+            "command '{}' return with error (code {}): {}".format(
+                e.cmd, e.returncode, e.output
+            )
+        )
 
     sequence_info = {
         chain.id: SequenceInfo(

--- a/big-structure/src/destress_big_structure/analysis.py
+++ b/big-structure/src/destress_big_structure/analysis.py
@@ -260,7 +260,7 @@ def analyse_design(design: ampal.Assembly) -> DesignMetrics:
     try:
         ev.tag_dssp_data(design)
     except subprocess.CalledProcessError as e:
-        print(e.stdout)
+        print(e.stderr)
         pass
 
     sequence_info = {

--- a/big-structure/src/destress_big_structure/analysis.py
+++ b/big-structure/src/destress_big_structure/analysis.py
@@ -260,8 +260,7 @@ def analyse_design(design: ampal.Assembly) -> DesignMetrics:
     try:
         ev.tag_dssp_data(design)
     except subprocess.CalledProcessError as e:
-        print(e.stderr)
-        pass
+        print(e)
 
     sequence_info = {
         chain.id: SequenceInfo(


### PR DESCRIPTION
Found a few PDB files that caused an error when running headless destress. We didn't have any error handling in place to deal with errors after running dssp from Isambard. After adding in some error handling, headless destress was able to run across the files without crashing. 